### PR TITLE
Change because Laravel upgrade 5.4

### DIFF
--- a/src/Krucas/LaravelUserEmailVerification/Console/MakeVerificationCommand.php
+++ b/src/Krucas/LaravelUserEmailVerification/Console/MakeVerificationCommand.php
@@ -2,13 +2,13 @@
 
 namespace Krucas\LaravelUserEmailVerification\Console;
 
-use Illuminate\Console\AppNamespaceDetectorTrait;
+use Illuminate\Console\DetectsApplicationNamespace;
 use Illuminate\Console\Command;
 use Illuminate\Support\Composer;
 
 class MakeVerificationCommand extends Command
 {
-    use AppNamespaceDetectorTrait;
+    use DetectsApplicationNamespace;
 
     /**
      * The console command name.


### PR DESCRIPTION
Based on Laravel 5.4 upgrade the "AppNamespaceDetectorTrait" need to replaced by "DetectsApplicationNamespace"
reference : https://laravel.com/docs/5.4/upgrade